### PR TITLE
[WIP] Use dotenv global parameters to allow easier variable management

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+ADMIN_USER_EMAIL={replace-me}
+ADMIN_USER_NAME={replace-me}
+ADMIN_USER_PWD={replace-me}
+BASE_URL={replace-me}
+PORT=80
+SECRET_KEY_BASE={replace-me}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,13 +32,11 @@ services:
       - plausible_events_db
       - mail
     ports:
-      - 80:8000
+      - ${PORT}:8000
     links:
       - plausible_db
       - plausible_events_db
       - mail
-    env_file:
-      - plausible-conf.env
 
 volumes:
   db-data:

--- a/plausible-conf.env
+++ b/plausible-conf.env
@@ -1,5 +1,0 @@
-ADMIN_USER_EMAIL={replace-me}
-ADMIN_USER_NAME={replace-me}
-ADMIN_USER_PWD={replace-me}
-BASE_URL={replace-me}
-SECRET_KEY_BASE={replace-me}


### PR DESCRIPTION
With this change, we can set the `PORT` variable (currently not possible since it gets ignored).

Also, using `.env` parameters get passed automatically to the `docker-compose.yml` file and to the containers themselves, allowing easier container management.