### PR TITLE
Use docker compose override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docker-compose.custom.yml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Plausible Analytics setup examples
 
-This repository acts as a a template to get up and running with [Plausible Analytics](https://github.com/plausible/analytics).
+This repository acts as a template to get up and running with [Plausible Analytics](https://github.com/plausible/analytics).
 
 ### How to use
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,11 @@
+version: "3.3"
+services:
+  plausible_db:
+    ports:
+      - 5432:5432
+  plausible_events_db:
+    ports:
+      - 8123:8123
+  plausible:
+    ports:
+      - 80:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
       - db-data:/var/lib/postgresql/data
     environment:
       - POSTGRES_PASSWORD=postgres
-    ports:
-      - 5432:5432
 
   plausible_events_db:
     image: yandex/clickhouse-server:latest
@@ -21,8 +19,6 @@ services:
       nofile:
         soft: 262144
         hard: 262144
-    ports:
-      - 8123:8123
 
   plausible:
     image: plausible/analytics:latest
@@ -31,8 +27,6 @@ services:
       - plausible_db
       - plausible_events_db
       - mail
-    ports:
-      - 80:8000
     links:
       - plausible_db
       - plausible_events_db


### PR DESCRIPTION
I was wondering if we could NOT expose ports for services in `docker-compose.yml` by default.

The current `docker-compose.yml` has the following disadvantages:

1. You can't have a PostgreSQL database running on the host.
2. The db, plausible_events_db services are reachable from external IP addresses (this probably not a thing we want).
3. You can't have an HTTP server running on the host.
4. You need to be root to expose to port 80.

My proposition would be to:

1. Disable port exposure on `db`, `plausible_events_db` services
2. Disable port exposure on `plausible` service
3. Create a `docker-compose.override.yml` which would expose all ports
4. Add `docker-compose.custom.yml` to `.gitignore`

This way if someone doesn't care about all of that they can still `docker-compose up -d` and in case someone wants to perform advanced setup they don't have to deal with stashing changes etc.