### PR TITLE
Remove useless links

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,10 +29,6 @@ services:
       - mail
     ports:
       - 80:8000
-    links:
-      - plausible_db
-      - plausible_events_db
-      - mail
     env_file:
       - plausible-conf.env
 

--- a/geoip/docker-compose.geoip.yml
+++ b/geoip/docker-compose.geoip.yml
@@ -3,15 +3,11 @@ services:
   plausible:
     depends_on:
       - geoip
-    links:
-      - geoip
     environment:
       - GEOLITE2_COUNTRY_DB=/geoip/GeoLite2-Country.mmdb
 
   geoip:
     image: maxmindinc/geoipupdate
-    ports:
-      - 1080:1080
     environment:
       - GEOIPUPDATE_EDITION_IDS=GeoLite2-Country
       - GEOIPUPDATE_FREQUENCY=168 # update every 7 days


### PR DESCRIPTION
- Remove useless links
- Don't expose GeoIP ports

Links are[ kind of deprecated](https://docs.docker.com/compose/compose-file/#links) and completely useless since docker-compose 3 (tested on my self hosted instance)

I've also removed the GeoIP ports, as it was not done [here](https://github.com/plausible/hosting/commit/891914e9a110e26b198f0764635b373be571468f) 

