### PR TITLE
Update plausible-conf.env - remove the brackets around env var values

### DIFF
--- a/plausible-conf.env
+++ b/plausible-conf.env
@@ -1,5 +1,5 @@
-ADMIN_USER_EMAIL={replace-me}
-ADMIN_USER_NAME={replace-me}
-ADMIN_USER_PWD={replace-me}
-BASE_URL={replace-me}
-SECRET_KEY_BASE={replace-me}
+ADMIN_USER_EMAIL=replace-me
+ADMIN_USER_NAME=replace-me
+ADMIN_USER_PWD=replace-me
+BASE_URL=replace-me
+SECRET_KEY_BASE=replace-me


### PR DESCRIPTION
I got confused why I couldn't log in even though the credentials were correct.

Turns out you're supposed to remove the brackets around the env variables - I didn't knew that. I think this will prove less confusing