### PR TITLE
Add configuration for various reverse proxies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - plausible_events_db
       - mail
     ports:
-      - 80:8000
+      - 8000:8000
     env_file:
       - plausible-conf.env
 

--- a/reverse-proxy/README.md
+++ b/reverse-proxy/README.md
@@ -1,0 +1,9 @@
+This directory contains pre-made configurations for various reverse proxies. Which flavor you should choose depends on your setup.
+
+## No existing reverse proxy
+
+If you aren't running an existing reverse proxy, then you can use the [`caddy-gen`](https://github.com/wemake-services/caddy-gen) based docker-compose file. Update it to include the domain name you use for your server, then combine it with the existing docker-compose files:
+
+```shell
+$ docker-compose -f docker-compose.yml -f reverse-proxy/docker-compose.caddy-gen.yml up
+```

--- a/reverse-proxy/README.md
+++ b/reverse-proxy/README.md
@@ -16,10 +16,20 @@ If you are already running a reverse proxy, then the above will not work as it w
 
 If you already have NGINX running as a system service, use the configuration file in the `nginx` directory.
 
-Edit the file `reverse-proxy/nginx/plausible` to contain the domain name you use for your server, then copy it into NGINX's configuration folder. Enable it by creating a symlink in NGINX's enabled sites folder. Finally use Certbot to create a TLS certificate for your site.
+Edit the file `reverse-proxy/nginx/plausible` to contain the domain name you use for your server, then copy it into NGINX's configuration folder. Enable it by creating a symlink in NGINX's enabled sites folder. Finally use Certbot to create a TLS certificate for your site:
 
 ```shell
 $ sudo cp reverse-proxy/nginx/plausible /etc/nginx/sites-available
 $ sudo ln -s /etc/nginx/sites-available/plausible /etc/nginx/sites-enabled/plausible
 $ sudo certbot --nginx
+```
+
+### Traefik 2
+
+If you already have a Traefik container running on Docker, use the docker-compose file in the `traefik` directory. Note that it assumes that your Traefik container is set up to support certificate generation.
+
+Edit the file `reverse-proxy/traefik/docker-compose.traefik.yml` to contain the domain name you use for your server, then combine it with the existing docker-compose files:
+
+```shell
+$ docker-compose -f docker-compose.yml -f reverse-proxy/traefik/docker-compose.traefik.yml up
 ```

--- a/reverse-proxy/README.md
+++ b/reverse-proxy/README.md
@@ -7,3 +7,19 @@ If you aren't running an existing reverse proxy, then you can use the [`caddy-ge
 ```shell
 $ docker-compose -f docker-compose.yml -f reverse-proxy/docker-compose.caddy-gen.yml up
 ```
+
+## Existing reverse proxy
+
+If you are already running a reverse proxy, then the above will not work as it will clash with the existing port bindings. You should instead use one of the available configuration files:
+
+### NGINX
+
+If you already have NGINX running as a system service, use the configuration file in the `nginx` directory.
+
+Edit the file `reverse-proxy/nginx/plausible` to contain the domain name you use for your server, then copy it into NGINX's configuration folder. Enable it by creating a symlink in NGINX's enabled sites folder. Finally use Certbot to create a TLS certificate for your site.
+
+```shell
+$ sudo cp reverse-proxy/nginx/plausible /etc/nginx/sites-available
+$ sudo ln -s /etc/nginx/sites-available/plausible /etc/nginx/sites-enabled/plausible
+$ sudo certbot --nginx
+```

--- a/reverse-proxy/docker-compose.caddy-gen.yml
+++ b/reverse-proxy/docker-compose.caddy-gen.yml
@@ -16,7 +16,6 @@ services:
   plausible:
     labels:
       virtual.host: "example.com" # change to your domain name
-      virtual.alias: "www.example.com" # change to any aliases you use (or remove)
       virtual.port: "8000"
       virtual.tls-email: "admin@example.com" # change to your email
         

--- a/reverse-proxy/docker-compose.caddy-gen.yml
+++ b/reverse-proxy/docker-compose.caddy-gen.yml
@@ -14,8 +14,6 @@ services:
       - plausible
 
   plausible:
-    ports:
-      - 8000:8000
     labels:
       virtual.host: "example.com" # change to your domain name
       virtual.alias: "www.example.com" # change to any aliases you use (or remove)
@@ -25,4 +23,3 @@ services:
 volumes:
     caddy-certificates:
         driver: local
-        

--- a/reverse-proxy/docker-compose.caddy-gen.yml
+++ b/reverse-proxy/docker-compose.caddy-gen.yml
@@ -1,0 +1,28 @@
+version: "3.3"
+services:
+  caddy-gen:
+    container_name: caddy-gen
+    image: "wemakeservices/caddy-gen:latest"
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - caddy-certificates:/data/caddy
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - plausible
+
+  plausible:
+    ports:
+      - 8000:8000
+    labels:
+      virtual.host: "example.com" # change to your domain name
+      virtual.alias: "www.example.com" # change to any aliases you use (or remove)
+      virtual.port: "8000"
+      virtual.tls-email: "admin@example.com" # change to your email
+        
+volumes:
+    caddy-certificates:
+        driver: local
+        

--- a/reverse-proxy/nginx/plausible
+++ b/reverse-proxy/nginx/plausible
@@ -1,0 +1,9 @@
+server {
+	# replace example.com with your domain name
+	server_name example.com;
+
+	location / {
+		proxy_pass http://127.0.0.1:8000;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+	}
+}

--- a/reverse-proxy/traefik/docker-compose.traefik.yml
+++ b/reverse-proxy/traefik/docker-compose.traefik.yml
@@ -1,0 +1,8 @@
+version: "3.3"
+services:
+  plausible:
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.plausible.rule: "Host(`example.com`)" # change to your domain name
+      traefik.http.routers.plausible.entrypoints: "websecure"
+      traefik.http.services.plausible.loadbalancer.server.port: "8000"


### PR DESCRIPTION
This PR adds configurations for putting reverse proxies in front of Plausible.

It provides a docker-compose file for use when the host machine does not have an existing reverse proxy running. This is the most "plug-and-play" solution, since it handles everything through the docker-compose file. It will however clash with any reverse proxy that is already running on the host machine, since it binds to port 80/443.

If the host machine is already running a reverse proxy, then said proxy should be configured instead. The PR includes configs for NGINX and Traefik. The NGINX configuration is based on the one posted in #8 (by me), while the Traefik configuration is based on the one posted in #10 (by @MoryCorp).

The PR also includes a README file with instructions on getting the reverse proxy working.

**BREAKING CHANGE**: the root docker-compose file has been updated to change the host port plausible binds to. It used to be port 80, but since most reverse proxies are intended to proxy both HTTP and HTTPS traffic, this has been changed to port 8000.