### PR TITLE
Add clickhouse configuration to disable logging tables

### DIFF
--- a/clickhouse/clickhouse-config.xml
+++ b/clickhouse/clickhouse-config.xml
@@ -1,0 +1,14 @@
+<yandex>
+    <logger>
+        <level>warning</level>
+        <console>true</console>
+    </logger>
+
+    <!-- Stop all the unnecessary logging -->
+    <query_thread_log remove="remove"/>
+    <query_log remove="remove"/>
+    <text_log remove="remove"/>
+    <trace_log remove="remove"/>
+    <metric_log remove="remove"/>
+    <asynchronous_metric_log remove="remove"/>
+</yandex>

--- a/clickhouse/clickhouse-user-config.xml
+++ b/clickhouse/clickhouse-user-config.xml
@@ -1,0 +1,8 @@
+<yandex>
+    <profiles>
+        <default>
+            <log_queries>0</log_queries>
+            <log_query_threads>0</log_query_threads>
+        </default>
+    </profiles>
+</yandex>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     image: yandex/clickhouse-server:latest
     volumes:
       - event-data:/var/lib/clickhouse
+      - ./clickhouse/clickhouse-config.xml:/etc/clickhouse-server/config.d/docker_related_config.xml:ro
+      - ./clickhouse/clickhouse-user-config.xml:/etc/clickhouse-server/users.d/docker_related_user_config.xml:ro
     ulimits:
       nofile:
         soft: 262144


### PR DESCRIPTION
These tables aren't appropriate for small-scale installations, especially for single home use.

I've been running this configuration without issue for a few months and it's great. Compared to a stock installation the resource footprint is significantly smaller.

See https://theorangeone.net/posts/calming-down-clickhouse/ and https://github.com/plausible/analytics/issues/301 for more information as to why this is necessary.