### PR TITLE
Changed Postgres version from 12 to latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     restart: always
 
   plausible_db:
-    image: postgres:12
+    image: postgres:latest # or 13
     volumes:
       - db-data:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
By switching to the latest or 13 version, the plausible_db container will no more complain about the wrong postgres version and shut down. This resolved my error, when i implemented this docker-compose into my own docker-compose.