### PR TITLE
Issues with hosting_plausible_events_db_1 creation

### DIFF
--- a/clickhouse/clickhouse-config.xml
+++ b/clickhouse/clickhouse-config.xml
@@ -11,4 +11,5 @@
     <trace_log remove="remove"/>
     <metric_log remove="remove"/>
     <asynchronous_metric_log remove="remove"/>
+    <listen_host>0.0.0.0</listen_host>
 </yandex>


### PR DESCRIPTION
hosting_plausible_1 is unable to connect to hosting_plausible_events_db_1 host on port 8123.
docker logs hosting_plausible_1  show the following error(removed the rest for clarity):
```
** (UndefinedFunctionError) function :econnrefused.exception/1 is undefined (module :econnrefused is not available)
```

docker logs hosting_plausible_events_db_1 show the following error:
```
<Warning> Application: Listen [::1]:8123 failed: Poco::Exception. Code: 1000, e.code() = 99, e.displayText() = Net Exception: Cannot assign requested address: [::1]:8123 (version 20.11.4.13 (official build)). If it is an IPv6 or IPv4 address and your host has disabled IPv6 or IPv4, then consider to specify not disabled IPv4 or IPv6 address to listen in <listen_host> element of configuration file. Example for disabled IPv6: <listen_host>0.0.0.0</listen_host> . Example for disabled IPv4: <listen_host>::</listen_host>
``` 
And for some reason, it being a warning (probably because of this https://github.com/ClickHouse/ClickHouse/issues/4406) it doesn't bind the port.

So this change will only listen on ipv4 and fix the problem.