### PR TITLE
Instructs Nginx to listen on both IPv6 and IPv4

### DIFF
--- a/reverse-proxy/nginx/plausible
+++ b/reverse-proxy/nginx/plausible
@@ -1,6 +1,9 @@
 server {
 	# replace example.com with your domain name
 	server_name example.com;
+	
+	listen 80;
+	listen [::]:80;
 
 	location / {
 		proxy_pass http://127.0.0.1:8000;


### PR DESCRIPTION
On a server which has both IPv4 and IPv6 configured, `sudo certbot --nginx` would fail because certbot looks for both A and AAAA DNS records, and if AAAA (IPv6) is found it uses that. 

By adding:

```
listen 80;
listen [::]:80;
```

issue #22 is solved. Servers which have only IPv4 configured should continue working normally I think.

If IPv4 only servers do not work after applying this change, maybe this should be added to the docs instead...?