### PR TITLE
Make plausible/analytics container port local only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - plausible_events_db
       - mail
     ports:
-      - 8000:8000
+      - 127.0.0.1:8000:8000
     env_file:
       - plausible-conf.env
 


### PR DESCRIPTION
This change makes the container plausible/analytics accessible only from localhost (127.0.0.1). 

I think that this should be the default because:
- to use plausible with a https website, plausible should be served from https. Requires reverse proxy.
- using plausible with http makes it vulnerable to "hackers" when entering admin password and the entire traffic can be seen by "anyone", thus making it insecure.

The docs should reflect these points even if this PR is not accepted.