### PR TITLE
Create plausible-smtp.env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - 8000:8000
     env_file:
       - plausible-conf.env
-
+      - plausible-smtp.env
 volumes:
   db-data:
     driver: local

--- a/plausible-smtp.env
+++ b/plausible-smtp.env
@@ -6,4 +6,3 @@ SMTP_USER_NAME=replace-me
 SMTP_USER_PWD=replace-me
 SMTP_HOST_SSL_ENABLED=replace-me
 SMTP_RETRIES=replace-me
-CRON_ENABLED=true

--- a/plausible-smtp.env
+++ b/plausible-smtp.env
@@ -1,0 +1,9 @@
+#Email Configuration for weekly/monthly reporting as per https://plausible.io/docs/self-hosting-configuration#mailersmtp-setup
+MAILER_EMAIL=replace-me
+SMTP_HOST_ADDR=replace-me
+SMTP_HOST_PORT=replace-me
+SMTP_USER_NAME=replace-me
+SMTP_USER_PWD=replace-me
+SMTP_HOST_SSL_ENABLED=replace-me
+SMTP_RETRIES=replace-me
+CRON_ENABLED=true


### PR DESCRIPTION
Email Configuration for weekly/monthly stats' reporting based on [Plausible's email configuration options](https://plausible.io/docs/self-hosting-configuration#mailersmtp-setup).
