### PR TITLE
Use latest versioned clickhouse

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - POSTGRES_PASSWORD=postgres
 
   plausible_events_db:
-    image: yandex/clickhouse-server:20.3.8.53
+    image: yandex/clickhouse-server:latest
     volumes:
       - event-data:/var/lib/clickhouse
       - ./clickhouse/clickhouse-config.xml:/etc/clickhouse-server/config.d/logging.xml:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - POSTGRES_PASSWORD=postgres
 
   plausible_events_db:
-    image: yandex/clickhouse-server:latest
+    image: yandex/clickhouse-server:21.3.2.5
     volumes:
       - event-data:/var/lib/clickhouse
       - ./clickhouse/clickhouse-config.xml:/etc/clickhouse-server/config.d/logging.xml:ro


### PR DESCRIPTION
This reverts the previous commit which uses an older version of clickhouse and prevents plausible from starting. 

The updated version uses the most recent versioned release.
```bash
plausible_events_db_1`  | 2021.03.12 15:36:29.730102 [ 1 ] {} <Error> Application: Caught exception while loading metadata: Code: 62, e.displayText() = DB::Exception: Syntax error (in file /var/lib/clickhouse/metadata/system.sql): failed at position 19 (line 1, col 19): UUID '0bc5f958-0314-4a89-8e4c-16127775b690'
plausible_events_db_1  | ENGINE = Atomic
plausible_events_db_1  | . Expected one of: storage definition, ENGINE, ON, Stack trace (when copying this message, always include the lines below):
plausible_events_db_1  | 
plausible_events_db_1  | 0. Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x10542450 in /usr/bin/clickhouse
plausible_events_db_1  | 1. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x8f4272d in /usr/bin/clickhouse
plausible_events_db_1  | 2. ? @ 0xe0850a7 in /usr/bin/clickhouse
plausible_events_db_1  | 3. ? @ 0xd5799d9 in /usr/bin/clickhouse
plausible_events_db_1  | 4. DB::loadMetadataSystem(DB::Context&) @ 0xd57c024 in /usr/bin/clickhouse
plausible_events_db_1  | 5. DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) @ 0x8fc5fde in /usr/bin/clickhouse
plausible_events_db_1  | 6. ? @ 0x10464907 in /usr/bin/clickhouse
plausible_events_db_1  | 7. DB::Server::run() @ 0x8f97045 in /usr/bin/clickhouse
plausible_events_db_1  | 8. mainEntryClickHouseServer(int, char**) @ 0x8f8de23 in /usr/bin/clickhouse
plausible_events_db_1  | 9. main @ 0x8ee9799 in /usr/bin/clickhouse
plausible_events_db_1  | 10. __libc_start_main @ 0x21b97 in /lib/x86_64-linux-gnu/libc-2.27.so
plausible_events_db_1  | 11. _start @ 0x8ee902e in /usr/bin/clickhouse
plausible_events_db_1  |  (version 20.3.8.53 (official build))
caddy-gen              | dockergen.1 | 2021/03/12 15:36:29 Contents of /etc/caddy/Caddyfile did not change. Skipping notification ''
plausible_events_db_1  | 2021.03.12 15:36:29.739624 [ 1 ] {} <Error> Application: DB::Exception: Syntax error (in file /var/lib/clickhouse/metadata/system.sql): failed at position 19 (line 1, col 19): UUID '0bc5f958-0314-4a89-8e4c-16127775b690'
plausible_events_db_1  | ENGINE = Atomic
plausible_events_db_1  | . Expected one of: storage definition, ENGINE, ON
```