### PR TITLE
Add Restart Ability to all the Containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
 
   plausible_db:
     image: postgres:12
+    restart: always
     volumes:
       - db-data:/var/lib/postgresql/data
     environment:
@@ -13,6 +14,7 @@ services:
 
   plausible_events_db:
     image: yandex/clickhouse-server:21.3.2.5
+    restart: always
     volumes:
       - event-data:/var/lib/clickhouse
       - ./clickhouse/clickhouse-config.xml:/etc/clickhouse-server/config.d/logging.xml:ro
@@ -24,6 +26,7 @@ services:
 
   plausible:
     image: plausible/analytics:latest
+    restart: always
     command: sh -c "sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh db init-admin && /entrypoint.sh run"
     depends_on:
       - plausible_db

--- a/geoip/docker-compose.geoip.yml
+++ b/geoip/docker-compose.geoip.yml
@@ -10,6 +10,7 @@ services:
 
   geoip:
     image: maxmindinc/geoipupdate
+    restart: always
     environment:
       - GEOIPUPDATE_EDITION_IDS=GeoLite2-Country
       - GEOIPUPDATE_FREQUENCY=168 # update every 7 days


### PR DESCRIPTION
Currently, only the SMTP container restarts in case of a system reboot which can cause issues with tracking. This adds the restart option to all the containers.