### PR TITLE
fixed incorrect selector for SMTP service

### DIFF
--- a/kubernetes/plausible-mail.yaml
+++ b/kubernetes/plausible-mail.yaml
@@ -15,7 +15,7 @@ spec:
       protocol: TCP
   selector:
     app.kubernetes.io/name: smtp
-    app.kubernetes.io/component: database
+    app.kubernetes.io/component: email
     app.kubernetes.io/part-of: plausible
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
The selector was set incorrectly and hence would point to nothing causing 500 errors when sending emails. I must have not correctly tested the SMTP when I originally created the Kubernetes configurations hence this mistake made it through.