### PR TITLE
Update clickhouse to 22.4.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Plausible Analytics setup examples
 
-This repository acts as a a template to get up and running with [Plausible Analytics](https://github.com/plausible/analytics).
+This repository acts as a template to get up and running with [Plausible Analytics](https://github.com/plausible/analytics).
 
 ### How to use
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - POSTGRES_PASSWORD=postgres
 
   plausible_events_db:
-    image: yandex/clickhouse-server:21.3.2.5
+    image: clickhouse/clickhouse-server:22.6-alpine
     restart: always
     volumes:
       - event-data:/var/lib/clickhouse


### PR DESCRIPTION
That version supports ARM and switches to alpine, which is 50MB smaller than Ubuntu (300MB) image.