### PR TITLE
Fixed link to self hosting docs in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository acts as a template to get up and running with [Plausible Analyti
 
 ### How to use
 
-Find instructions on how to run Plausible Analytics Self Hosted [in our docs](https://docs.plausible.io/self-hosting).
+Find instructions on how to run Plausible Analytics Self Hosted [in our docs](https://plausible.io/docs/self-hosting).
 
 ### Contributing
 


### PR DESCRIPTION
The old link goes to an unused url.