### PR TITLE
update clickhouse to 22.9 for better arm64 support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - POSTGRES_PASSWORD=postgres
 
   plausible_events_db:
-    image: clickhouse/clickhouse-server:22.9-alpine
+    image: clickhouse/clickhouse-server:23.3.7.5-alpine
     restart: always
     volumes:
       - event-data:/var/lib/clickhouse

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - POSTGRES_PASSWORD=postgres
 
   plausible_events_db:
-    image: clickhouse/clickhouse-server:22.6-alpine
+    image: clickhouse/clickhouse-server:22.9-alpine
     restart: always
     volumes:
       - event-data:/var/lib/clickhouse

--- a/kubernetes/plausible-events-db.yaml
+++ b/kubernetes/plausible-events-db.yaml
@@ -79,7 +79,7 @@ spec:
         fsGroup: 101
       containers:
         - name: plausible-events-db
-          image: yandex/clickhouse-server:latest
+          image: clickhouse/clickhouse-server:22.9-alpine
           imagePullPolicy: Always
           ports:
             - containerPort: 8123


### PR DESCRIPTION
Relevant: https://github.com/plausible/analytics/discussions/2292

**tl;dr** In [22.9](https://clickhouse.com/docs/en/whats-new/changelog/#-clickhouse-release-229-2022-09-22) ClickHouse [switched](https://github.com/ClickHouse/ClickHouse/pull/38171) from [`hyperscan`](https://github.com/intel/hyperscan) to [`vectorscan`](https://github.com/VectorCamp/vectorscan) and multi-substring search now works on arm64.

I'm trying it out on my instance and everything seems to be going well so far.