### PR TITLE
Remove admin creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
   plausible:
     image: plausible/analytics:latest
     restart: always
-    command: sh -c "sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh db init-admin && /entrypoint.sh run"
+    command: sh -c "sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh run"
     depends_on:
       - plausible_db
       - plausible_events_db

--- a/plausible-conf.env
+++ b/plausible-conf.env
@@ -1,5 +1,2 @@
-ADMIN_USER_EMAIL=replace-me
-ADMIN_USER_NAME=replace-me
-ADMIN_USER_PWD=replace-me
 BASE_URL=replace-me
 SECRET_KEY_BASE=replace-me


### PR DESCRIPTION
If you bring up services through the current *docker-compose.yml* file, you see the following in the logs:

```
plausible-1  | init-admin is deprecated and is no-op now
plausible-1  | user registration on first launch happens via Web UI instead
```

On similar lines, when you go to the UI after that, it asks you to create an admin user by providing a user name, password and email.

So, this PR removes the code that no longer works.