### PR TITLE
Update Clickhouse logging suppression XML

### DIFF
--- a/clickhouse/clickhouse-config.xml
+++ b/clickhouse/clickhouse-config.xml
@@ -1,4 +1,4 @@
-<yandex>
+<clickhouse>
     <logger>
         <level>warning</level>
         <console>true</console>
@@ -11,4 +11,6 @@
     <trace_log remove="remove"/>
     <metric_log remove="remove"/>
     <asynchronous_metric_log remove="remove"/>
-</yandex>
+    <session_log remove="remove"/>
+    <part_log remove="remove"/>
+</clickhouse>

--- a/clickhouse/clickhouse-user-config.xml
+++ b/clickhouse/clickhouse-user-config.xml
@@ -1,8 +1,8 @@
-<yandex>
+<clickhouse>
     <profiles>
         <default>
             <log_queries>0</log_queries>
             <log_query_threads>0</log_query_threads>
         </default>
     </profiles>
-</yandex>
+</clickhouse>


### PR DESCRIPTION
After digging into the Clickhouse documentation, it seems like these changes might be needed.

In the Docker Hub `clickhouse/clickhouse-server:22.6-alpine` image, I actually observed that the container's `/etc/clickhouse-server/config.xml` (and `users.xml` file) both implement a root-level node of `<clickhouse>`, not `<yandex>`.

According to the Clickhouse documentation [here](https://clickhouse.com/docs/en/operations/configuration-files/), it says:
> All XML files should have the same root element, usually `<clickhouse>`.

Therefore, it would seem like these changes are needed.

This would agree with the recent rebranding of some of these components from Yandex to Clickhouse.

Unfortunately, I don't have a good means of validating these changes, outside of the above reasoning. (It would appear to fail silently and write bigger log files, if it was wrongly implemented... this is hard to validate in isolation.)

The newly added parameters in `clickhouse-config.yml` were added because the original author of these files noted in their blog post that newer Clickhouse versions required these missing parameters:
https://theorangeone.net/posts/calming-down-clickhouse/#reduce-logging