### PR TITLE
Update Kubernetes manifests

### DIFF
--- a/kubernetes/plausible-db.yaml
+++ b/kubernetes/plausible-db.yaml
@@ -42,15 +42,16 @@ spec:
         app.kubernetes.io/part-of: plausible
     spec:
       restartPolicy: Always
-      # see https://github.com/docker-library/postgres/blob/6bbf1c7b308d1c4288251d73c37f6caf75f8a3d4/14/buster/Dockerfile
+      # 70 is the standard UID/GID for "postgres" in Alpine.
+      # See  https://github.com/docker-library/postgres/blob/156d0659d047578f06aa8785cf12d547c6a5ccfd/14/alpine/Dockerfile#L9
       securityContext:
-        runAsUser: 999
-        runAsGroup: 999
-        fsGroup: 999
+        runAsUser: 70
+        runAsGroup: 70
+        fsGroup: 70
       containers:
         - name: plausible-db
-          # supported versions are 12, 13, and 14
-          image: postgres:latest
+          # Postgres v14 is recommended
+          image: postgres:14-alpine
           imagePullPolicy: Always
           ports:
             - containerPort: 5432

--- a/kubernetes/plausible-events-db.yaml
+++ b/kubernetes/plausible-events-db.yaml
@@ -24,7 +24,7 @@ metadata:
   name: plausible-events-db-config
 data:
   clickhouse-config.xml: |
-    <yandex>
+    <clickhouse>
         <logger>
             <level>warning</level>
             <console>true</console>
@@ -37,16 +37,18 @@ data:
         <trace_log remove="remove"/>
         <metric_log remove="remove"/>
         <asynchronous_metric_log remove="remove"/>
-    </yandex>
+        <session_log remove="remove"/>
+        <part_log remove="remove"/>
+    </clickhouse>
   clickhouse-user-config.xml: |
-    <yandex>
+    <clickhouse>
         <profiles>
             <default>
                 <log_queries>0</log_queries>
                 <log_query_threads>0</log_query_threads>
             </default>
         </profiles>
-    </yandex>
+    </clickhouse>
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -72,14 +74,15 @@ spec:
         app.kubernetes.io/part-of: plausible
     spec:
       restartPolicy: Always
-      # see https://github.com/ClickHouse/ClickHouse/blob/master/docker/server/Dockerfile
+      # The same UID / GID (101) is used both for Alpine and Ubuntu.
+      # See https://github.com/ClickHouse/ClickHouse/blob/master/docker/server/Dockerfile.ubuntu#L42
       securityContext:
         runAsUser: 101
         runAsGroup: 101
         fsGroup: 101
       containers:
         - name: plausible-events-db
-          image: yandex/clickhouse-server:latest
+          image: clickhouse/clickhouse-server:22.6-alpine
           imagePullPolicy: Always
           ports:
             - containerPort: 8123


### PR DESCRIPTION
I run Plausible on AKS. I use the Kubernetes Terraform module for deployment, but my config is pretty much analog to the Kubernetes manifests in this repo. Here are the changes I've made to my config:

https://github.com/schnerring/infrastructure-core/compare/ccc8b1d2378979e2ae3e7ad7a42dd107716f70ba..b590979c2285e67a54acd44384b2398698ae1242

I thought it might be useful to consolidate the changes with you guys while I'm on it. This syncs up the manifests with the recent docker-compose updates you've made.

As a side note, I think we could remove the following from `clickhouse-user-config.xml`:

```xml
<log_query_threads>0</log_query_threads>
```

[It seems to be the default since ClickHouse v22.5](https://clickhouse.com/docs/en/whats-new/changelog/2022#-clickhouse-release-225-2022-05-19]:

> Disable `log_query_threads` setting by default. It controls the logging of statistics about every thread participating in query execution. After supporting asynchronous reads, the total number of distinct thread ids became too large, and logging into the query_thread_log has become too heavy.