### PR TITLE
feat: Replace old bytemark/smtp image with the source code

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   mail:
-    image: bytemark/smtp
+    build: ./smtp/latest 
     restart: always
 
   plausible_db:

--- a/smtp/README.md
+++ b/smtp/README.md
@@ -1,0 +1,96 @@
+> Original repo can be found [here](https://github.com/BytemarkHosting/docker-smtp)
+
+## Supported tags
+
+* [`stretch`, `latest` (*stretch/Dockerfile*)](https://github.com/BytemarkHosting/docker-smtp/blob/master/stretch/Dockerfile)
+
+## Quick reference
+
+This image allows linked containers to send outgoing email. You can configure
+it to send email directly to recipients, or to act as a smart host that relays
+mail to an intermediate server (eg, GMail, SendGrid).
+
+* **Code repository:**
+  https://github.com/BytemarkHosting/docker-smtp
+* **Where to file issues:**
+  https://github.com/BytemarkHosting/docker-smtp/issues
+* **Maintained by:**
+  [Bytemark Hosting](https://www.bytemark.co.uk)
+* **Supported architectures:**
+  [Any architecture that has the Debian `exim4-daemon-light` package](https://packages.debian.org/stretch/exim4-daemon-light)
+
+## Usage
+
+### Basic SMTP server
+
+In this example, linked containers can connect to hostname `mail` and port `25`
+to send outgoing email. The SMTP container sends email out directly.
+
+```
+docker run --restart always --name mail -d bytemark/smtp
+
+```
+
+#### Via Docker Compose:
+
+```
+version: '3'
+services:
+  mail:
+    image: bytemark/smtp
+    restart: always
+
+```
+
+### SMTP smart host
+
+In this example, linked containers can connect to hostname `mail` and port `25`
+to send outgoing email. The SMTP container acts as a smart host and relays mail
+to an intermediate server server (eg, GMail, SendGrid).
+
+```
+docker run --restart always --name mail \
+    -e RELAY_HOST=smtp.example.com \
+    -e RELAY_PORT=587 \
+    -e RELAY_USERNAME=alice@example.com \
+    -e RELAY_PASSWORD=secretpassword \
+    -d bytemark/smtp
+
+```
+
+#### Via Docker Compose:
+
+```
+version: '3'
+services:
+  mail:
+    image: bytemark/smtp
+    restart: always
+    environment:
+      RELAY_HOST: smtp.example.com
+      RELAY_PORT: 587
+      RELAY_USERNAME: alice@example.com
+      RELAY_PASSWORD: secretpassword
+
+```
+
+### Environment variables
+
+All environment variables are optional. But if you specify a `RELAY_HOST`, then
+you'll want to also specify the port, username and password otherwise it's
+unlikely to work!
+
+* **`MAILNAME`**: Sets Exim's `primary_hostname`, which defaults to the
+  hostname of the server.
+* **`RELAY_HOST`**: The remote SMTP server address to use.
+* **`RELAY_PORT`**: The remote SMTP server port to use.
+* **`RELAY_USERNAME`**: The username to authenticate with the remote SMTP
+  server.
+* **`RELAY_PASSWORD`**: The password to authenticate with the remote SMTP
+  server.
+* **`RELAY_NETS`**: Declare which networks can use the smart host, separated by
+  semi-colons. By default, this is set to
+  `10.0.0.0/8;172.16.0.0/12;192.168.0.0/16`, which provides a thin layer of
+  protection in case port 25 is accidentally exposed to the public internet
+  (which would make your SMTP container an open relay).
+

--- a/smtp/latest
+++ b/smtp/latest
@@ -1,0 +1,1 @@
+stretch

--- a/smtp/stretch/Dockerfile
+++ b/smtp/stretch/Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:stretch-slim
+
+# Install exim4
+ENV DEBIAN_FRONTEND noninteractive
+RUN set -ex; \
+    apt-get update; \
+    apt-get install -y exim4-daemon-light; \
+    apt-get clean
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+EXPOSE 25/tcp
+ENTRYPOINT [ "docker-entrypoint.sh" ]
+CMD [ "exim", "-bdf", "-v", "-q30m" ]

--- a/smtp/stretch/docker-entrypoint.sh
+++ b/smtp/stretch/docker-entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -e
+CONFDIR=/etc/exim4
+
+# By default, send email directly to the recipient.
+DC_EXIMCONFIG_CONFIGTYPE="internet"
+
+# By default, only hosts on the private network can use the smart host (ie,
+# only other containers, not the whole internet); a thin layer of protection
+# in case port 25 is accidentally exposed to the public internet.
+DC_RELAY_NETS="10.0.0.0/8;172.16.0.0/12;192.168.0.0/16"
+
+# If RELAY_HOST has been set then switch to smart host configuration.
+if [ "x$RELAY_HOST" != "x" ]; then
+    DC_EXIMCONFIG_CONFIGTYPE="satellite"
+    DC_SMARTHOST="$RELAY_HOST::${RELAY_PORT:-25}"
+    if [ "x$RELAY_USERNAME" != "x" ] && [ "x$RELAY_PASSWORD" != "x" ]; then
+        printf '%s\n' "*:$RELAY_USERNAME:$RELAY_PASSWORD" > "$CONFDIR/passwd.client"
+    fi
+fi
+
+# Set which hosts can use the smart host.
+if [ "x$RELAY_NETS" != "x" ]; then
+    DC_RELAY_NETS="$RELAY_NETS"
+fi
+
+# Write exim configuration.
+cat << EOF > "$CONFDIR/update-exim4.conf.conf"
+dc_eximconfig_configtype='$DC_EXIMCONFIG_CONFIGTYPE'
+dc_other_hostnames=''
+dc_local_interfaces=''
+dc_readhost=''
+dc_relay_domains=''
+dc_minimaldns='false'
+dc_relay_nets='$DC_RELAY_NETS'
+dc_smarthost='${DC_SMARTHOST:-}'
+CFILEMODE='644'
+dc_use_split_config='false'
+dc_hide_mailname='true'
+dc_mailname_in_oh='true'
+dc_localdelivery='mail_spool'
+EOF
+
+# Set primary_hostname.
+if [ "x$MAILNAME" != "x" ]; then
+    printf '%s\n' "$MAILNAME" > /etc/mailname
+    printf '%s\n' "MAIN_HARDCODE_PRIMARY_HOSTNAME=$MAILNAME" >> "$CONFDIR/update-exim4.conf.conf"
+fi
+
+# Apply exim configuration.
+update-exim4.conf
+
+exec "$@"


### PR DESCRIPTION
This will allow more platforms to use this template repo. The original dockerhub image was last updated 5 years ago, and as such, newer architectures aren't supported like the Raspberry Pi 4 which a lot of people are using for self hosting these days