### PR TITLE
use newer clickhouse version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - POSTGRES_PASSWORD=postgres
 
   plausible_events_db:
-    image: clickhouse/clickhouse-server:22.6-alpine
+    image: clickhouse/clickhouse-server:22.8.13.20-alpine
     restart: always
     volumes:
       - event-data:/var/lib/clickhouse


### PR DESCRIPTION
This PR updates the ClickHouse version used by default to `22.8.13.20` (the version used in Plausible tests)

Relevant: https://github.com/plausible/analytics/discussions/3026

- [x] I'll try it out on my self-hosted instance tomorrow