### PR TITLE
Updated docker-compose for easier migration and better plausible startup handle

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: postgres:14-alpine
     restart: always
     volumes:
-      - ./db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql/data
     environment:
       - POSTGRES_PASSWORD=postgres
     healthcheck:
@@ -22,7 +22,7 @@ services:
     image: clickhouse/clickhouse-server:23.3.7.5-alpine
     restart: always
     volumes:
-      - ./event-data:/var/lib/clickhouse
+      - event-data:/var/lib/clickhouse
       - ./clickhouse/clickhouse-config.xml:/etc/clickhouse-server/config.d/logging.xml:ro
       - ./clickhouse/clickhouse-user-config.xml:/etc/clickhouse-server/users.d/logging.xml:ro
     ulimits:
@@ -47,3 +47,9 @@ services:
       - 8000:8000
     env_file:
       - plausible-conf.env
+
+volumes:
+  db-data:
+    driver: local
+  event-data:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,37 +9,41 @@ services:
     image: postgres:14-alpine
     restart: always
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - ./db-data:/var/lib/postgresql/data
     environment:
       - POSTGRES_PASSWORD=postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   plausible_events_db:
     image: clickhouse/clickhouse-server:23.3.7.5-alpine
     restart: always
     volumes:
-      - event-data:/var/lib/clickhouse
+      - ./event-data:/var/lib/clickhouse
       - ./clickhouse/clickhouse-config.xml:/etc/clickhouse-server/config.d/logging.xml:ro
       - ./clickhouse/clickhouse-user-config.xml:/etc/clickhouse-server/users.d/logging.xml:ro
     ulimits:
       nofile:
         soft: 262144
         hard: 262144
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:8123/?query=SELECT%201 || exit 1
 
   plausible:
     image: plausible/analytics:v2.0
     restart: always
-    command: sh -c "sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh run"
+    command: sh -c "/entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh run"
     depends_on:
-      - plausible_db
-      - plausible_events_db
-      - mail
+      plausible_db:
+        condition: service_healthy
+      plausible_events_db:
+        condition: service_healthy
+      mail:
+        condition: service_started
     ports:
       - 8000:8000
     env_file:
       - plausible-conf.env
-
-volumes:
-  db-data:
-    driver: local
-  event-data:
-    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=postgres
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
+      test: ["CMD", "pg_isready", "-U", "postgres"]
 
   plausible_events_db:
     image: clickhouse/clickhouse-server:23.3.7.5-alpine
@@ -30,7 +27,7 @@ services:
         soft: 262144
         hard: 262144
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:8123/?query=SELECT%201 || exit 1
+      test: ["CMD", "clickhouse-client", "-q", "SELECT 1"]
 
   plausible:
     image: plausible/analytics:v2.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - POSTGRES_PASSWORD=postgres
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 5s
 
   plausible_events_db:
     image: clickhouse/clickhouse-server:23.3.7.5-alpine
@@ -28,6 +29,7 @@ services:
         hard: 262144
     healthcheck:
       test: ["CMD", "clickhouse-client", "-q", "SELECT 1"]
+      interval: 5s
 
   plausible:
     image: plausible/analytics:v2.0


### PR DESCRIPTION
In this PR, `docker-compose` is updated:
* Removed volumes settings make it easier to migrate between hosts, related: https://github.com/plausible/hosting/pull/66
* Added `healthcheck` for containers to make sure DB and ClickHouse is started before plausible container
* There is no need to wait extra 10 seconds inside plausible container as `depends_on` can make sure DB and ClickHouse are already started
* smtp container not touched as https://github.com/plausible/hosting/pull/43 seems stuck, while if smtp is still needed we can use GitHub Actions to maintain a multi-arch version of it.