### PR TITLE
Replaced smtp image to work on arm64

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   mail:
-    image: bytemark/smtp
+    image: sverzegnassi/smtp
     restart: always
 
   plausible_db:


### PR DESCRIPTION
The currently used smtp image does not run on arm64. The [replaced one](https://hub.docker.com/r/sverzegnassi/smtp/tags) does run on amd64 as well as arm64. This is a fairly random repo and as such a potential security risk but i couldn't find a better one. I would fork it myself but that would not be much better

See https://github.com/BytemarkHosting/docker-smtp/issues/10
Link to the repo: https://github.com/sverzegnassi/docker-smtp