### PR TITLE
Remove bind to 127.0.0.1 and allow Docker to bind to all IP addresses

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - plausible_events_db
       - mail
     ports:
-      - 127.0.0.1:8000:8000
+      - 8000:8000
     env_file:
       - plausible-conf.env
 


### PR DESCRIPTION
Please see my change, this way you can run this `docker-compose.yml` file inside a VM and only expose the port 8000 instead of having the reverse proxy inside that VM too.

I ran into this issue when trying to run Plausible inside a VM inside a Kubernetes cluster where the Ingress will act as the proxy. 

Looking forward to hear your opinion!