### PR TITLE
Remove version tag from compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   mail:
     image: bytemark/smtp


### PR DESCRIPTION
Docker has deprecated this tag.
Having it fires the warning: 
``docker-compose.yml: `version` is obsolete``