### PR TITLE
Fix Nginx websocket config

### DIFF
--- a/reverse-proxy/nginx/plausible
+++ b/reverse-proxy/nginx/plausible
@@ -8,8 +8,11 @@ server {
 	location / {
 		proxy_pass http://127.0.0.1:8000;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_http_version 1.1;
-		proxy_set_header Upgrade $http_upgrade;
-		proxy_set_header Connection "Upgrade";
+
+		location = /live/websocket {
+			proxy_http_version 1.1;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection "Upgrade";
+		}
 	}
 }


### PR DESCRIPTION
As noticed in https://github.com/plausible/analytics/discussions/4128 the websocket config should only concern websocket endopints (i.e. `/live/websocket`) and not all endpoints (`/`).