### PR TITLE
Fix Nginx websocket config: proxy_pass is not inherited

### DIFF
--- a/reverse-proxy/nginx/plausible
+++ b/reverse-proxy/nginx/plausible
@@ -10,6 +10,7 @@ server {
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
 		location = /live/websocket {
+			proxy_pass http://127.0.0.1:8000;
 			proxy_http_version 1.1;
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
Whoops! Hit "create pull request" a bit too fast. The `proxy_pass` directive is not inherited in child `location` blocks and should be specified again.