### PR TITLE
Add DATABASE_SOCKET_DIR and related to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,57 @@ Plausible uses PostgreSQL for storing user data and ClickhouseDB for analytics d
 
 Default: `postgres://postgres:postgres@plausible_db:5432/plausible_db`
 
-Configures the URL for PostgreSQL database.
+Configures the URL for PostgreSQL database. **Cannot** be used to connect to Unix domain socket. See [DATABASE_SOCKET_DIR](#database_socket_dir).
+
+---
+
+#### DATABASE_SOCKET_DIR
+
+Overrides [DATABASE_URL](#database_url). Configures the socket directory to use for PostgreSQL database. Not set by default
+
+<sub><kbd>plausible-conf.env</kbd></sub>
+```env
+DATABASE_SOCKET_DIR=/run/postgresql
+```
+
+You may need to additionally specify [DATABASE_NAME](#database_name), [PGUSER](#pguser), and [PGPASSWORD](#pgpassword).
+
+---
+
+#### DATABASE_NAME
+
+Default: Current user
+
+Only relevant with [DATABASE_SOCKET_DIR](#database_socket_dir). Configures the database name to use.
+
+<sub><kbd>plausible-conf.env</kbd></sub>
+```env
+DATABASE_NAME=plausible_db
+```
+
+---
+
+#### PGUSER
+
+Default: Current user
+
+Only relevant with [DATABASE_SOCKET_DIR](#database_socket_dir). Configures the database role to use for authentication.
+
+<sub><kbd>plausible-conf.env</kbd></sub>
+```env
+PGUSER=plausible_role
+```
+
+---
+
+#### PGPASSWORD
+
+Only relevant with [DATABASE_SOCKET_DIR](#database_socket_dir). Configures the database password to use for authentication. Not set by default.
+
+<sub><kbd>plausible-conf.env</kbd></sub>
+```env
+PGPASSWORD="Correct Battery Horse Staple"
+```
 
 ---
 


### PR DESCRIPTION
Support for connecting to PostgreSQL via Unix domain socket was added a couple of years ago, and this should help advertise that support.

There are 3 additional influential variables that users should expect to need defining:
- DATABASE_NAME
- PGUSER
- PGPASSWORD

While DATABASE_NAME is Plausible-specific, PGUSER and PGPASSWORD support comes from the underlying database driver. Rather than making users dig through code and commit history for this info (because the driver doesn't document this either), we include it here for ease of access.