### PR TITLE
Add ws proxy to apache2/plausible.conf

### DIFF
--- a/reverse-proxy/apache2/plausible.conf
+++ b/reverse-proxy/apache2/plausible.conf
@@ -4,6 +4,8 @@
  ServerName example.com
 
  ProxyPreserveHost On
+ ProxyAddHeaders On
+ ProxyPassMatch ^/(live/websocket)$  ws://localhost:8000/$1
  ProxyPass / http://localhost:8000/
  ProxyPassReverse / http://localhost:8000/
 


### PR DESCRIPTION
Websocket connections on apache2 were failing until it was routed correctly - caused token creation to fail.