### PR TITLE
Fix low resources settings for Clickhouse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !clickhouse/logs.xml
 !clickhouse/ipv4-only.xml
 !clickhouse/low-resources.xml
+!clickhouse/default-profile-low-resources-overrides.xml
 !README.md
 !LICENSE
 !.gitignore

--- a/clickhouse/default-profile-low-resources-overrides.xml
+++ b/clickhouse/default-profile-low-resources-overrides.xml
@@ -1,0 +1,19 @@
+<!-- https://clickhouse.com/docs/en/operations/tips#using-less-than-16gb-of-ram -->
+<clickhouse>
+    <profiles>
+        <default>
+            <!-- https://clickhouse.com/docs/en/operations/settings/settings#max_threads -->
+            <max_threads>1</max_threads>
+            <!-- https://clickhouse.com/docs/en/operations/settings/settings#max_block_size -->
+            <max_block_size>8192</max_block_size>
+            <!-- https://clickhouse.com/docs/en/operations/settings/settings#max_download_threads -->
+            <max_download_threads>1</max_download_threads>
+            <!--
+            https://clickhouse.com/docs/en/operations/settings/settings#input_format_parallel_parsing -->
+            <input_format_parallel_parsing>0</input_format_parallel_parsing>
+            <!--
+            https://clickhouse.com/docs/en/operations/settings/settings#output_format_parallel_formatting -->
+            <output_format_parallel_formatting>0</output_format_parallel_formatting>
+        </default>
+    </profiles>
+</clickhouse>

--- a/clickhouse/low-resources.xml
+++ b/clickhouse/low-resources.xml
@@ -1,23 +1,4 @@
-<!-- https://clickhouse.com/docs/en/operations/tips#using-less-than-16gb-of-ram -->
 <clickhouse>
-    <!--
-    https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#mark_cache_size -->
+    <!-- https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#mark_cache_size -->
     <mark_cache_size>524288000</mark_cache_size>
-
-    <profile>
-        <default>
-            <!-- https://clickhouse.com/docs/en/operations/settings/settings#max_threads -->
-            <max_threads>1</max_threads>
-            <!-- https://clickhouse.com/docs/en/operations/settings/settings#max_block_size -->
-            <max_block_size>8192</max_block_size>
-            <!-- https://clickhouse.com/docs/en/operations/settings/settings#max_download_threads -->
-            <max_download_threads>1</max_download_threads>
-            <!--
-            https://clickhouse.com/docs/en/operations/settings/settings#input_format_parallel_parsing -->
-            <input_format_parallel_parsing>0</input_format_parallel_parsing>
-            <!--
-            https://clickhouse.com/docs/en/operations/settings/settings#output_format_parallel_formatting -->
-            <output_format_parallel_formatting>0</output_format_parallel_formatting>
-        </default>
-    </profile>
 </clickhouse>

--- a/compose.yml
+++ b/compose.yml
@@ -20,9 +20,10 @@ services:
       # This makes ClickHouse bind to IPv4 only, since Docker doesn't enable IPv6 in bridge networks by default.
       # Fixes "Listen [::]:9000 failed: Address family for hostname not supported" warnings.
       - ./clickhouse/ipv4-only.xml:/etc/clickhouse-server/config.d/ipv4-only.xml:ro
-      # This makes ClickHouse consume less resources, which is useful for small setups.
+      # The following configuration files make ClickHouse consume less resources, which is useful for small setups.
       # https://clickhouse.com/docs/en/operations/tips#using-less-than-16gb-of-ram
       - ./clickhouse/low-resources.xml:/etc/clickhouse-server/config.d/low-resources.xml:ro
+      - ./clickhouse/default-profile-low-resources-overrides.xml:/etc/clickhouse-server/users.d/default-profile-low-resources-overrides.xml:ro
     ulimits:
       nofile:
         soft: 262144
@@ -30,7 +31,11 @@ services:
     environment:
       - CLICKHOUSE_SKIP_USER_SETUP=1
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 -O - http://127.0.0.1:8123/ping || exit 1"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget --no-verbose --tries=1 -O - http://127.0.0.1:8123/ping || exit 1",
+        ]
       start_period: 1m
 
   plausible:


### PR DESCRIPTION
Fixes https://github.com/plausible/community-edition/issues/264

Overrides for the default profile were ignored if they were not in the folder `/etc/clickhouse-server/users.d`. https://clickhouse.com/docs/operations/configuration-files#user-settings

After this fix:
```
SELECT
    name,
    value,
    changed
FROM system.settings
WHERE changed = 1

Query id: dec4544d-3c80-4037-b44f-7254d01ebe3e

   ┌─name──────────────────────────────┬─value─┬─changed─┐
1. │ max_block_size                    │ 8192  │       1 │
2. │ max_threads                       │ 1     │       1 │
3. │ max_download_threads              │ 1     │       1 │
4. │ input_format_parallel_parsing     │ 0     │       1 │
5. │ output_format_parallel_formatting │ 0     │       1 │
   └───────────────────────────────────┴───────┴─────────┘
```

```
SELECT
    name,
    value
FROM system.server_settings
WHERE name = 'mark_cache_size'

Query id: e19aadd9-e5e4-4b11-9c4d-170c8d1bf5ac

   ┌─name────────────┬─value─────┐
1. │ mark_cache_size │ 524288000 │
   └─────────────────┴───────────┘
```