### PR TITLE
Make compose.yml compatible with selinux-enabled systems

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -16,14 +16,14 @@ services:
     volumes:
       - event-data:/var/lib/clickhouse
       - event-logs:/var/log/clickhouse-server
-      - ./clickhouse/logs.xml:/etc/clickhouse-server/config.d/logs.xml:ro
+      - ./clickhouse/logs.xml:/etc/clickhouse-server/config.d/logs.xml:ro,Z
       # This makes ClickHouse bind to IPv4 only, since Docker doesn't enable IPv6 in bridge networks by default.
       # Fixes "Listen [::]:9000 failed: Address family for hostname not supported" warnings.
-      - ./clickhouse/ipv4-only.xml:/etc/clickhouse-server/config.d/ipv4-only.xml:ro
+      - ./clickhouse/ipv4-only.xml:/etc/clickhouse-server/config.d/ipv4-only.xml:ro,Z
       # The following configuration files make ClickHouse consume less resources, which is useful for small setups.
       # https://clickhouse.com/docs/en/operations/tips#using-less-than-16gb-of-ram
-      - ./clickhouse/low-resources.xml:/etc/clickhouse-server/config.d/low-resources.xml:ro
-      - ./clickhouse/default-profile-low-resources-overrides.xml:/etc/clickhouse-server/users.d/default-profile-low-resources-overrides.xml:ro
+      - ./clickhouse/low-resources.xml:/etc/clickhouse-server/config.d/low-resources.xml:ro,Z
+      - ./clickhouse/default-profile-low-resources-overrides.xml:/etc/clickhouse-server/users.d/default-profile-low-resources-overrides.xml:ro,Z
     ulimits:
       nofile:
         soft: 262144


### PR DESCRIPTION
Without this change the compose file will not work on an selinux-enabled systems. The "Z" flag sets labels for files on the volume so that the container can read them.

URL: https://manpages.org/docker-run
URL: https://docs.podman.io/en/latest/markdown/podman-run.1.html