### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@
     A getting started guide to self-hosting <a href="https://plausible.io/blog/community-edition">Plausible Community Edition</a>
 </p>
 
+<p align="center">
+    <a href="https://zenith.hosting/host/plausible"><img alt="Deploy with Zenith" src="https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg" height="40"></a>
+</p>
+
+<p align="center">
+    Rather not run the server yourself? One-click managed CE hosting, with a share of every subscription going back to Plausible.
+</p>
+
 ---
 
 ### Prerequisites


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Plausible to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the README intro, above the self-hosting guide (links to https://zenith.hosting/host/plausible).

we share a cut of revenue with the projects we host, so a CE instance running on Zenith funds Plausible too. happy to explain if you're curious: hello@zenith.hosting