### PR TITLE
Disable processors_profile_log

### DIFF
--- a/clickhouse/logs.xml
+++ b/clickhouse/logs.xml
@@ -25,4 +25,5 @@
     <trace_log remove="remove" />
     <session_log remove="remove" />
     <part_log remove="remove" />
+    <processors_profile_log remove="remove" />
 </clickhouse>


### PR DESCRIPTION
Closes #275. Refs #256.

## Problem

`processors_profile_log` is enabled by default in ClickHouse and is not in the disable list in `clickhouse/logs.xml`. It writes a row per processor for **every** query regardless of duration, and its table has **no TTL**, so it grows without bound. #275 reports it reaching almost 2 GB.

For comparison, `query_log` — the one system log table this setup deliberately keeps — is capped at 30 days:

```
processors_profile_log → MergeTree PARTITION BY toYYYYMM(event_date) ORDER BY (event_date, event_time)
query_log              → MergeTree PARTITION BY event_date ORDER BY event_time TTL event_date + toIntervalDay(30)
```

## Measurements

ClickHouse 24.12.6.70 (matching the `24.12-alpine` pin in `compose.yml`) with this repo's `logs.xml` in `config.d/`, running an identical six-query workload against both configs followed by `SYSTEM FLUSH LOGS`:

**Before**

```
┌─table──────────────────┬─rows─┬─size──────┐
│ processors_profile_log │  217 │ 8.70 KiB  │
│ query_log              │   15 │ 12.16 KiB │
│ error_log              │    1 │ 890.00 B  │
└────────────────────────┴──────┴───────────┘
```

**After**

```
┌─table─────┬─rows─┬─size──────┐
│ query_log │   15 │ 12.12 KiB │
│ error_log │    1 │ 890.00 B  │
└───────────┴──────┴───────────┘
```

That is 217 rows from 6 queries — roughly 36 rows per query, about 41 bytes per row on disk — accumulating permanently at many times `query_log`'s row rate.

## Change

```xml
<processors_profile_log remove="remove" />
```

Same `remove="remove"` idiom already used in this file.

## Note for a possible follow-up

While checking this I found three more default-enabled log tables that are also missing from the disable list and also have no TTL: `query_metric_log` (added in ClickHouse 24.10, after this file's list was written), `error_log` (added in 24.8), and `query_views_log`. They are all far smaller than `processors_profile_log` — `query_metric_log` only records queries running over a second, at about one row per second, and `query_views_log` wrote nothing in my test — so I have left them out to keep this PR to the one table #275 is about. Happy to open a follow-up if you would like them disabled too.

`crash_log` is worth keeping either way: it writes only on crashes and is useful for diagnosing the OOM kills small instances hit. `asynchronous_insert_log` and `blob_storage_log` already carry their own TTLs (3 and 30 days), so they are self-limiting.

## Reproducing

```console
$ clickhouse server --config-file=config.xml     # 24.12, with logs.xml in config.d/
$ clickhouse client --query "SYSTEM FLUSH LOGS"
$ clickhouse client --query "
    SELECT table, sum(rows) AS rows, formatReadableSize(sum(bytes_on_disk)) AS size
    FROM system.parts WHERE active AND database='system'
    GROUP BY table ORDER BY rows DESC"
```

I tested against a standalone 24.12.6.70 server rather than a full CE stack, so the row counts come from a synthetic workload rather than real dashboard traffic. The absent TTL and the per-query row rate are properties of the ClickHouse configuration itself and hold regardless.
